### PR TITLE
Update Node to 10.14.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.14.1-alpine
+FROM node:10.14.2-alpine
 
 RUN apk update && \
     apk upgrade && \


### PR DESCRIPTION
The latest update of Jest (26.0.1) requires Node >= 10.14.2 (previously >= 8.3).

Jest-action was using 10.14.1 and hence would fail. Updating to use `node:10.14.2-alpine` seemed to have it working again.